### PR TITLE
Include OpenSSL versions in release tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: macos-14
 
     env: # use tag version, if available, falling back to 1.21.3 (stable)
-      MITKERBEROS_VERSION: "${{ startsWith(github.ref, 'refs/tags/1.') && github.ref_name || '1.21.3' }}"
+      MITKERBEROS_VERSION: "${{ startsWith(github.ref, 'refs/tags/1.') && github.ref_name || '1.21.3_openssl-3.3.1' }}"
       PUBLISH_RELEASE: "${{ startsWith(github.ref, 'refs/tags/1.') && '1' || '0' }}"
 
     steps:


### PR DESCRIPTION
The plain `krb5` version (e.g. `1.21.3`) is extended with a suffix (e.g. `_openssl-3.3.1`)

This makes it unambiguous which OpenSSL version was used, allowing downstream consumers to specify the exact `krb5`/`openssl` version combination they need.

Build script now includes the OpenSSL version in downloaded/extracted artifacts, to help local testing with several side-by-side versions.